### PR TITLE
always_run is deprecated. Use check_mode = no instead..

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,11 @@ Changed
 
 - Mostly automated update to the lastest DebOps Standards Version. [ypid_]
 
+Fixed
+~~~~~
+
+- Fix Ansible 2.2 deprecation warnings. [brzhk]
+
 
 `debops.logrotate v0.1.2`_ - 2016-07-05
 ---------------------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,7 +24,7 @@ Changed
 Fixed
 ~~~~~
 
-- Fix Ansible 2.2 deprecation warnings. [brzhk]
+- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher. Support for older Ansible versions is dropped. [brzhk]
 
 
 `debops.logrotate v0.1.2`_ - 2016-07-05

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,7 +24,8 @@ Changed
 Fixed
 ~~~~~
 
-- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher. Support for older Ansible versions is dropped. [brzhk]
+- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher.
+  Support for older Ansible versions is dropped. [brzhk]
 
 
 `debops.logrotate v0.1.2`_ - 2016-07-05

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   description: 'Manage log rotation configuration'
   company: 'DebOps'
   license: 'GPL-3.0'
-  min_ansible_version: '2.0.0'
+  min_ansible_version: '2.2.0'
 
   platforms:
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -51,7 +51,7 @@
     LC_ALL: 'C'
   shell: dpkg-divert --list '/etc/logrotate.d/*.dpkg-divert' | awk '{print $NF}'
   register: logrotate__register_diversions
-  check_mode: no
+  check_mode: False
   changed_when: False
 
 - name: Divert the custom log rotation config

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -51,7 +51,7 @@
     LC_ALL: 'C'
   shell: dpkg-divert --list '/etc/logrotate.d/*.dpkg-divert' | awk '{print $NF}'
   register: logrotate__register_diversions
-  always_run: True
+  check_mode: no
   changed_when: False
 
 - name: Divert the custom log rotation config


### PR DESCRIPTION
[DEPRECATION WARNING]: always_run is deprecated. Use check_mode = no instead..
This feature will be removed in version 2.4. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.