### PR TITLE
Fix meta/main.yml line break issue

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,21 +3,16 @@
 dependencies: []
 
 galaxy_info:
-
   author: 'Maciej Delmanowski'
   description: 'Manage log rotation configuration'
   company: 'DebOps'
   license: 'GPL-3.0'
   min_ansible_version: '2.2.0'
-
   platforms:
-
     - name: 'Ubuntu'
       versions: [ 'all' ]
-
     - name: 'Debian'
       versions: [ 'all' ]
-
   galaxy_tags:
     - system
     - logs


### PR DESCRIPTION
The line breaks in meta/main.yml caused the following error on our side : 

`ERROR! Unexpected Exception: [Errno 2] No such file or directory: '/.../roles/.galaxy/debops.logrotate/meta/.galaxy_install_info`

This PR fixed the issue.